### PR TITLE
Add default django logging at INFO level to build and prod settings file

### DIFF
--- a/payment_gateway/settings/build.py
+++ b/payment_gateway/settings/build.py
@@ -23,3 +23,33 @@ INSTALLED_APPS = BUILTIN_APPS + THIRD_PARTY_APPS + DEV_APPS + PROJECT_APPS
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '-m*c=fbc#x&@3-ezm+sfh3w+h#y9-qog(jk$i+c5)rgk=b2fzh'
+
+# Automatic Django logging at the INFO level (i.e everything the comes to the console when ran locally)
+LOGGING = {
+  'version': 1,
+  'disable_existing_loggers': False,
+  'formatters': {
+    'console': {
+            # exact format is not important, this is the minimum information
+            'format': '%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+        },
+        },
+  'handlers': {
+    'django.server': {
+        'level': 'INFO',
+        'class': 'logging.handlers.RotatingFileHandler',
+        'maxBytes': 1 * 1024 * 1024,
+        'filename': 'logs/output.log',
+        'formatter': 'console',
+        'maxBytes': 1 * 1024 * 1024,
+        'backupCount': '30'
+    },
+   },
+   'loggers': {
+     'django.server': {
+       'handlers': ['django.server'],
+         'level': 'INFO',
+           'propagate': True,
+      },
+    },
+}

--- a/payment_gateway/settings/prod.py
+++ b/payment_gateway/settings/prod.py
@@ -22,3 +22,33 @@ MIDDLEWARE = MIDDLEWARE + PROD_MIDDLEWARE
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '5xfw@*imgau)r!_h^i4p!gh0&e9s75!j6j3@g+7yri1jetk1%b'
+
+# Automatic Django logging at the INFO level (i.e everything the comes to the console when ran locally)
+LOGGING = {
+  'version': 1,
+  'disable_existing_loggers': False,
+  'formatters': {
+    'console': {
+            # exact format is not important, this is the minimum information
+            'format': '%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+        },
+        },
+  'handlers': {
+    'django.server': {
+        'level': 'INFO',
+        'class': 'logging.handlers.RotatingFileHandler',
+        'maxBytes': 1 * 1024 * 1024,
+        'filename': 'logs/output.log',
+        'formatter': 'console',
+        'maxBytes': 1 * 1024 * 1024,
+        'backupCount': '30'
+    },
+   },
+  'loggers': {
+     'django.server': {
+       'handlers': ['django.server'],
+         'level': 'INFO',
+           'propagate': True,
+      },
+    },
+}


### PR DESCRIPTION
As specified in ticket [CCN3-660] and subticket [CCN3-737]

For this ticket, all error catching was already added. But logging settings must have been removed on settings partitioning, so this has been re added.